### PR TITLE
Fix/all good eval logic

### DIFF
--- a/main.go
+++ b/main.go
@@ -429,7 +429,7 @@ func executeCheck(event *types.Event) (int, error) {
 		} else {
 			fmt.Printf("%v\n", string(response))
 		}
-		return sensu.CheckStateWarning, nil
+		return sensu.CheckStateOK, nil
 	}
 	return sensu.CheckStateOK, nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -269,7 +269,7 @@ func TestMultipleEval(t *testing.T) {
 	}
 	t.Run("test no eval", func(t *testing.T) {
 		status, err := executeCheck(nil)
-		if status != 1 {
+		if status != 0 {
 			t.Errorf("executeCheck(nil) status: %v err: %v", status, err)
 			return
 		}


### PR DESCRIPTION
Fix eval statement logic
Add a new set of tests to run to test handling return status of eval
1. no eval -> 0 status
1. single true eval -> 0 status
1. single false eval -> evalStatus 
1. mixed multiple eval -> evalstatus
1. multiple true eval -> 0 status 